### PR TITLE
set ismasked to false for responses

### DIFF
--- a/src/haxe/net/impl/WebSocketGeneric.hx
+++ b/src/haxe/net/impl/WebSocketGeneric.hx
@@ -380,7 +380,9 @@ class WebSocketGeneric extends WebSocket {
 
     private function prepareFrame(data:Bytes, type:Opcode, isFinal:Bool):Bytes {
         var out = new BytesRW();
-        var isMasked = true; // All clientes messages must be masked: http://tools.ietf.org/html/rfc6455#section-5.1
+	
+        //Chrome: VM321:1 WebSocket connection to 'ws://localhost:8000/' failed: A server must not mask any frames that it sends to the client.
+        var isMasked = false; //true; // All clientes messages must be masked: http://tools.ietf.org/html/rfc6455#section-5.1
         var mask = generateMask();
         var sizeMask = (isMasked ? 0x80 : 0x00);
 


### PR DESCRIPTION
Chrome 60.0.3112.113 complains that:
"A server must not mask any frames that it sends to the client."
And then closes the connection